### PR TITLE
Fix premature win by syncing player progress with camera

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,13 +55,15 @@ def run():
                     level = Level()
                     player = Player(120, HEIGHT - GROUND_HEIGHT - PLAYER_SIZE)
                     cam_x = 0.0
+                    jump_buffer = 0
                     state = STATE_PLAY
                 elif state == STATE_PLAY and event.key == pygame.K_SPACE:
                     jump_buffer = 6  # allow a small window to jump
 
         keys = pygame.key.get_pressed()
         if state == STATE_PLAY:
-            # Auto-runner: camera moves, player stays mostly near left
+            # Auto-runner: advance the player and camera together
+            player.advance(speed)
             cam_x += speed
 
             # Input: jump
@@ -82,7 +84,7 @@ def run():
                 state = STATE_DEAD
 
             # Win condition
-            if player.rect.centerx + cam_x >= level.finish_x:
+            if player.rect.centerx >= level.finish_x:
                 state = STATE_WIN
 
         # Drawing

--- a/objects.py
+++ b/objects.py
@@ -108,9 +108,15 @@ class Ground:
 class Player:
     def __init__(self, x, y):
         self.rect = pygame.Rect(x, y, PLAYER_SIZE, PLAYER_SIZE)
+        self._pos_x = float(self.rect.x)
         self.vel_y = 0
         self.on_ground = False
         self.rotation = 0.0  # for fun
+
+    def advance(self, dx: float):
+        """Move the player forward while keeping float precision."""
+        self._pos_x += dx
+        self.rect.x = int(round(self._pos_x))
 
     def update(self, ground: Ground, spikes: List[Spike]):
         # Apply gravity


### PR DESCRIPTION
## Summary
- track the player's horizontal position with float precision and expose an advance helper
- move the player forward each frame, reset the jump buffer on restart, and base the win check on the player's world x

## Testing
- python -m py_compile main.py objects.py level.py settings.py

------
https://chatgpt.com/codex/tasks/task_e_68c94b01bcb8832091be029a7132c409